### PR TITLE
--keep-graph (keep_graph) added as an option

### DIFF
--- a/pyprojectviz/__main__.py
+++ b/pyprojectviz/__main__.py
@@ -14,24 +14,33 @@ def main(
     path: str = typer.Argument(
         ..., help="Path to the project to generate the graph for"
     ),
-    output: str = typer.Option(None, help="Output file name"),
-    config: str = typer.Option(None, help="Path to the configuration file"),
+    output_file: str = typer.Option(None, "--output", help="Output file name"),
+    config_file: str = typer.Option(
+        None, "--config", help="Path to the configuration file"
+    ),
+    keep_graph: bool = typer.Option(
+        False, "--keep-graph", help="Keep the graphviz file after rendering"
+    ),
 ):
-    if not output:
+    if not output_file:
         date = datetime.now().strftime("%Y-%m_%d-%H-%M-%S")
-        output = f"pyprojectviz-{date}"
+        output_file = f"pyprojectviz-{date}"
 
     if not os.path.isdir(path):
         typer.echo("Invalid path to project")
         raise typer.Exit(code=1)
 
-    config = load_config(config)
+    config = load_config(config_file)
 
     project_path = Path(path).resolve()
     graph = generate_graph(project_path, config)
 
-    output_path = Path(output).resolve()
-    graph.render(output_path.as_posix(), view=False, cleanup=True, quiet=True)
+    output_path = Path(output_file).resolve()
+    graph.render(
+        output_path.as_posix(),
+        view=False,
+        cleanup=not keep_graph and not config.keep_graph,
+    )
     typer.echo(
         f"Graph generated at {output_path}.{config.graphviz.output_format}"
     )

--- a/pyprojectviz/config.py
+++ b/pyprojectviz/config.py
@@ -49,6 +49,7 @@ class Configuration(BaseModel):
     ignore_classes: Set[str] = set()
     ignore_modules: Set[str] = set()
     ignore_exceptions: bool = False
+    keep_graph: bool = False
 
 
 def load_config(conf_file) -> Configuration:

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -12,9 +12,10 @@ def test_app_success():
             ".",
             "--output",
             "test",
+            "--keep-graph",
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout
     assert "Graph generated at" in result.stdout
 
 


### PR DESCRIPTION
Added `--keep-graph` as an option to cli and keep_graph to configuration.
This allows the user to keep the graphviz generated file.

Solves #5 